### PR TITLE
Add path-style configurations for S3

### DIFF
--- a/src/baseTypes.ts
+++ b/src/baseTypes.ts
@@ -11,6 +11,7 @@ export interface S3Config {
   s3AccessKeyID: string;
   s3SecretAccessKey: string;
   s3BucketName: string;
+  forcePathStyle: boolean;
 }
 
 export interface DropboxConfig {

--- a/src/remoteForS3.ts
+++ b/src/remoteForS3.ts
@@ -34,6 +34,7 @@ export const DEFAULT_S3_CONFIG = {
   s3AccessKeyID: "",
   s3SecretAccessKey: "",
   s3BucketName: "",
+  forcePathStyle: false
 };
 
 export type S3ObjectType = _Object;
@@ -69,6 +70,7 @@ export const getS3Client = (s3Config: S3Config) => {
   const s3Client = new S3Client({
     region: s3Config.s3Region,
     endpoint: endpoint,
+    forcePathStyle: s3Config.forcePathStyle,
     credentials: {
       accessKeyId: s3Config.s3AccessKeyID,
       secretAccessKey: s3Config.s3SecretAccessKey,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -488,7 +488,7 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
     new Setting(s3Div)
       .setName("s3Region")
       .setDesc(
-        "s3Region: If you are not sure what to enter, you could try the vaule: us-east-1"
+        "s3Region: If you are not sure what to enter, you could try the value: us-east-1"
       )
       .addText((text) =>
         text
@@ -538,6 +538,20 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           })
       );
+      
+    new Setting(s3Div)
+      .setName("s3 URL Style")
+      .setDesc("Whether to use virtual-hosted style URLs (e.g. https://bucket.s3.amazonaws.com/) or path style URLs (e.g. https://s3.amazonaws.com/bucket/) for S3 objects.")
+      .addDropdown((dropdown) => {
+        dropdown.addOption("virtualHostedStyle", "Virtual Hosted Style");
+        dropdown.addOption("pathStyle", "Path Style");
+        dropdown
+          .setValue(this.plugin.settings.s3.forcePathStyle ? "pathStyle": "virtualHostedStyle")
+          .onChange(async (val: string) => {
+            this.plugin.settings.s3.forcePathStyle = (val == "pathStyle");
+            await this.plugin.saveSettings();
+          });
+      });
 
     new Setting(s3Div)
       .setName("check connectivity")


### PR DESCRIPTION
**Why this pull request?**

Though Amazon mentioned on its [blog](https://aws.amazon.com/cn/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) that path-style configurations will be depricated (but still not), for some self-hosted s3 services, like Minio, it's a common practice using the path style to identify buckets. This helps shrinking DNS records.

This plugin uses Amazon's s3-client for communication, while `forcePathStyle` is configurable through this.

**What changes in this PR**

It changes the settings to add a `s3 URL Style` option. In the S3Config, `forcePathStyle` is added too.

![image](https://user-images.githubusercontent.com/39787044/156794356-106c4be0-d893-40d6-a5d0-508ceb0ba66f.png)

Fixed a typo `vaule` to `value`.