### PR TITLE
Add ignorePaths setting

### DIFF
--- a/src/baseTypes.ts
+++ b/src/baseTypes.ts
@@ -86,6 +86,7 @@ export interface RemotelySavePluginSettings {
   lang?: LangTypeAndAuto;
   logToDB?: boolean;
   skipSizeLargerThan?: number;
+  ignorePaths?: string[];
 
   /**
    * @deprecated

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,7 @@ const DEFAULT_SETTINGS: RemotelySavePluginSettings = {
   lang: "auto",
   logToDB: false,
   skipSizeLargerThan: -1,
+  ignorePaths: [".obsidian/workspace.json", ".obsidian/workspace-mobile.json", ".obsidian/community-plugins.json"],
 };
 
 interface OAuth2Info {
@@ -296,6 +297,7 @@ export default class RemotelySavePlugin extends Plugin {
         this.app.vault.configDir,
         this.settings.syncUnderscoreItems,
         this.settings.skipSizeLargerThan,
+        this.settings.ignorePaths,
         this.settings.password
       );
       log.info(plan.mixedStates); // for debugging

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1596,6 +1596,18 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
           });
       });
 
+    new Setting(basicDiv)
+      .setName(t("settings_ignorepaths"))
+      .setDesc(t("settings_ignorepaths_desc"))
+      .addTextArea((textArea) => {
+        textArea
+          .setValue(`${this.plugin.settings.ignorePaths.join("\n")}`)
+          .onChange(async (value) => {
+            this.plugin.settings.ignorePaths = value.split("\n");
+            await this.plugin.saveSettings();
+          });
+      });
+
     //////////////////////////////////////////////////
     // below for advanced settings
     //////////////////////////////////////////////////

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -293,8 +293,12 @@ const isSkipItem = (
   key: string,
   syncConfigDir: boolean,
   syncUnderscoreItems: boolean,
-  configDir: string
+  configDir: string,
+  ignorePaths: string[]
 ) => {
+  if (ignorePaths.includes(key)) {
+    return true;
+  }
   if (syncConfigDir && isInsideObsFolder(key, configDir)) {
     return false;
   }
@@ -315,6 +319,7 @@ const ensembleMixedStates = async (
   syncConfigDir: boolean,
   configDir: string,
   syncUnderscoreItems: boolean,
+  ignorePaths: string[],
   password: string
 ) => {
   const results = {} as Record<string, FileOrFolderMixedState>;
@@ -322,7 +327,7 @@ const ensembleMixedStates = async (
   for (const r of remoteStates) {
     const key = r.key;
 
-    if (isSkipItem(key, syncConfigDir, syncUnderscoreItems, configDir)) {
+    if (isSkipItem(key, syncConfigDir, syncUnderscoreItems, configDir, ignorePaths)) {
       continue;
     }
     results[key] = r;
@@ -361,7 +366,7 @@ const ensembleMixedStates = async (
       throw Error(`unexpected ${entry}`);
     }
 
-    if (isSkipItem(key, syncConfigDir, syncUnderscoreItems, configDir)) {
+    if (isSkipItem(key, syncConfigDir, syncUnderscoreItems, configDir, ignorePaths)) {
       continue;
     }
 
@@ -395,6 +400,10 @@ const ensembleMixedStates = async (
           password === "" ? undefined : getSizeFromOrigToEnc(entry.size),
       };
 
+      if (isSkipItem(key, syncConfigDir, syncUnderscoreItems, configDir, ignorePaths)) {
+        continue;
+      }
+
       if (results.hasOwnProperty(key)) {
         results[key].key = r.key;
         results[key].existLocal = r.existLocal;
@@ -417,7 +426,7 @@ const ensembleMixedStates = async (
       deltimeRemoteFmt: unixTimeToStr(entry.actionWhen),
     } as FileOrFolderMixedState;
 
-    if (isSkipItem(key, syncConfigDir, syncUnderscoreItems, configDir)) {
+    if (isSkipItem(key, syncConfigDir, syncUnderscoreItems, configDir, ignorePaths)) {
       continue;
     }
 
@@ -445,7 +454,7 @@ const ensembleMixedStates = async (
       throw Error(`unexpected ${entry}`);
     }
 
-    if (isSkipItem(key, syncConfigDir, syncUnderscoreItems, configDir)) {
+    if (isSkipItem(key, syncConfigDir, syncUnderscoreItems, configDir, ignorePaths)) {
       continue;
     }
 
@@ -967,6 +976,7 @@ export const getSyncPlan = async (
   configDir: string,
   syncUnderscoreItems: boolean,
   skipSizeLargerThan: number,
+  ignorePaths: string[],
   password: string = ""
 ) => {
   const mixedStates = await ensembleMixedStates(
@@ -978,8 +988,10 @@ export const getSyncPlan = async (
     syncConfigDir,
     configDir,
     syncUnderscoreItems,
+    ignorePaths,
     password
   );
+  console.table(mixedStates)
 
   const sortedKeys = Object.keys(mixedStates).sort(
     (k1, k2) => k2.length - k1.length

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -991,7 +991,6 @@ export const getSyncPlan = async (
     ignorePaths,
     password
   );
-  console.table(mixedStates)
 
   const sortedKeys = Object.keys(mixedStates).sort(
     (k1, k2) => k2.length - k1.length


### PR DESCRIPTION
close #163

### Feature

This PR adds a `ignorePaths` setting. `ignorePaths` setting allows you to specify files or folders that you want to exclude from syncing. This feature is especially helpful when the option `Sync Config Dir (experimental)` is enabled.

### What Changed

- [x] add a `ignorePaths` setting
  - default is `[".obsidian/workspace.json", ".obsidian/workspace-mobile.json", ".obsidian/community-plugins.json"]`
- [x] add an Obsidian setting option
  - One path per line
  - ![image](https://github.com/remotely-save/remotely-save/assets/66677201/eb3ec939-6dca-4319-a239-4507aad53abc)
- [x] add i18n keys
  - `settings_ignorepaths` and `settings_ignorepaths_desc`
  - see https://github.com/remotely-save/langs/pull/4
  - I have no knoqledge of Chinese, so I would like you to correct the values if their are incorrect. :pray:
- [ ] add tests
  - where should I write tests ?
