### PR TITLE
docs: add s3:ListBucket requirement to s3 bucket permissions example

### DIFF
--- a/docs/remote_services/s3_general/s3_user_policy.md
+++ b/docs/remote_services/s3_general/s3_user_policy.md
@@ -32,7 +32,8 @@ Using the principle of least privilege is crucial for security when allowing a t
             "Sid": "ObsidianBucket",
             "Effect": "Allow",
             "Action": [
-                "s3:HeadBucket"
+                "s3:HeadBucket",
+                "s3:ListBucket"
             ],
             "Resource": "arn:aws:s3:::my-bucket"
         },


### PR DESCRIPTION
As per [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html) using `s3:HeadBucket` requires the `s3:ListBucket` permission as well. 

I came up against this when using the provided IAM policy directly, which resulted in a 403. Adding the `s3:ListBucket` permission allowed me to sync my vault to a fresh s3 bucket as expected.

Hopefully this addition saves others from having the same issue.