### PR TITLE
:lipstick: setings: overflow-wrap: break-word

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -811,6 +811,7 @@ export class RemotelySaveSettingTab extends PluginSettingTab {
 
   display(): void {
     let { containerEl } = this;
+    containerEl.style.setProperty("overflow-wrap", "break-word");
 
     containerEl.empty();
 


### PR DESCRIPTION
Fixed inconvenience of URLs not wrapping, especially in mobile.
I'd be happy to take your review.

|before|after|
|-|-|
|![image](https://github.com/remotely-save/remotely-save/assets/66677201/79956d24-8770-40eb-9511-7ae737cf3dc8)|![image](https://github.com/remotely-save/remotely-save/assets/66677201/8926328a-5531-4a4a-a762-9a4b64248b68)|

