### PR TITLE
fix bug of unwished synchronization of Config Directory and Bookmarks File

### DIFF
--- a/pro/src/sync.ts
+++ b/pro/src/sync.ts
@@ -202,15 +202,19 @@ export const checkIsSkipItemOrNotByName = (
       }
     }
   }
-  if (syncConfigDir && isInsideObsFolder(key, configDir)) {
-    if (finalIsIgnored === undefined) {
+  if (isInsideObsFolder(key, configDir) && finalIsIgnored === undefined) {
+    if(syncConfigDir){
       finalIsIgnored = false;
+    } else{
+      finalIsIgnored = true;
     }
   }
 
-  if (syncBookmarks && isBookmarksFile(key, configDir)) {
-    if (finalIsIgnored === undefined) {
+  if (isBookmarksFile(key, configDir) && finalIsIgnored === undefined) {
+    if(syncBookmarks){
       finalIsIgnored = false;
+    } else{
+      finalIsIgnored = true;
     }
   }
 


### PR DESCRIPTION
In the original code, if we set `syncConfigDir` to false, which means we don't want to sync this directory, but it will also cause 
`if( syncConfigDir && isInsideObsFolder(key, configDir) )`
statement **never** be entered.  

Thus, in the original code, our setting is actually **be ignored**.

Issues #814 and #804 may be caused by this.