### PR TITLE
Update docs/remote_services/webdav_nextcloud/README.md - add note that App Token is required if 2FA is enabled

### DIFF
--- a/docs/remote_services/webdav_nextcloud/README.md
+++ b/docs/remote_services/webdav_nextcloud/README.md
@@ -11,3 +11,5 @@
     * If you find installing Nextcloud by yourselves is difficult, you can find some "Nextcloud's trusted, certified providers" on [Nextcloud Sign up page](https://nextcloud.com/sign-up/); For example, [The Good Cloud](https://thegood.cloud/) there generously provides 2 GB free stoarage space.
     * Remotely Save is tested to be working with the docker version and The Good Cloud.
 2. Go to Nextcloud's settings. Find the webdav url (something like `https://cloud.example.com/remote.php/dav/files/USERNAME`). Use this (without tailing slash), and your account and your password, in Remotely Save.
+
+**NOTE:** If 2FA is enabled for your Nextcloud account, you need to setup an App Token instead of using your Password (`https://cloud.example.com/settings/user/security#generate-app-token-section`).


### PR DESCRIPTION
Note added about App Token Setup is required if 2FA is enabled.