### PR TITLE
feat: add sync direction commands to command palette

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1291,6 +1291,66 @@ export default class RemotelySavePlugin extends Plugin {
       },
     });
 
+    this.addCommand({
+      id: "sync-bidirectional",
+      name: t("setting_syncdirection_bidirectional_desc"),
+      icon: iconNameSyncWait,
+      callback: async () => {
+        const originalDirection = this.settings.syncDirection;
+        this.settings.syncDirection = "bidirectional";
+        await this.syncRun("manual");
+        this.settings.syncDirection = originalDirection;
+      },
+    });
+
+    this.addCommand({
+      id: "sync-increment-push",
+      name: t("setting_syncdirection_incremental_push_only_desc"),
+      icon: iconNameSyncWait,
+      callback: async () => {
+        const originalDirection = this.settings.syncDirection;
+        this.settings.syncDirection = "incremental_push_only";
+        await this.syncRun("manual");
+        this.settings.syncDirection = originalDirection;
+      },
+    });
+
+    this.addCommand({
+      id: "sync-increment-pull",
+      name: t("setting_syncdirection_incremental_pull_only_desc"),
+      icon: iconNameSyncWait,
+      callback: async () => {
+        const originalDirection = this.settings.syncDirection;
+        this.settings.syncDirection = "incremental_pull_only";
+        await this.syncRun("manual");
+        this.settings.syncDirection = originalDirection;
+      },
+    });
+
+    this.addCommand({
+      id: "sync-increment-push-with-deletion",
+      name: t("setting_syncdirection_incremental_push_and_delete_only_desc"),
+      icon: iconNameSyncWait,
+      callback: async () => {
+        const originalDirection = this.settings.syncDirection;
+        this.settings.syncDirection = "incremental_push_and_delete_only";
+        await this.syncRun("manual");
+        this.settings.syncDirection = originalDirection;
+      },
+    });
+
+    this.addCommand({
+      id: "sync-increment-pull-with-deletion",
+      name: t("setting_syncdirection_incremental_pull_and_delete_only_desc"),
+      icon: iconNameSyncWait,
+      callback: async () => {
+        const originalDirection = this.settings.syncDirection;
+        this.settings.syncDirection = "incremental_pull_and_delete_only";
+        await this.syncRun("manual");
+        this.settings.syncDirection = originalDirection;
+      },
+    });
+
     this.addSettingTab(new RemotelySaveSettingTab(this.app, this));
 
     // this.registerDomEvent(document, "click", (evt: MouseEvent) => {


### PR DESCRIPTION
# Add Sync Direction Commands to Command Palette

## Description
This PR adds five new commands to the command palette, allowing users to quickly execute sync operations with different sync directions without permanently changing their default sync direction setting.

The added commands are:
- **Bidirectional sync**: Sync changes in both directions
- **Incremental push**: Push local changes to remote (backup mode)
- **Incremental pull**: Pull remote changes to local
- **Incremental push with deletion**: Push local changes to remote and delete remote files that were deleted locally
- **Incremental pull with deletion**: Pull remote changes to local and delete local files that were deleted remotely

## Implementation
Each command temporarily changes the sync direction setting, executes the sync operation, and then restores the original setting. This provides a convenient way for users to perform different types of sync operations directly from the command palette.

## Benefits
- **Enables Git-like workflow**: Although there are some protection measures, bidirectional sync can cause confusion when adding new devices. These commands allow users to use Git-like logic to push and pull data, providing clearer control over synchronization direction.
- Improves user experience by making different sync directions easily accessible
- Eliminates the need to navigate to settings to change sync direction for one-time operations
- Particularly useful for users who frequently switch between different sync modes (e.g., backup vs. full sync)
