### PR TITLE
fix: OneDrive (for Business) 404 errors

### DIFF
--- a/pro/src/fsOnedriveFull.ts
+++ b/pro/src/fsOnedriveFull.ts
@@ -220,7 +220,7 @@ export const setConfigBySuccessfullAuthInplace = async (
  */
 const getOnedrivePath = (fileOrFolderPath: string, remoteBaseDir: string) => {
   // https://learn.microsoft.com/en-us/onedrive/developer/rest-api/concepts/addressing-driveitems?view=odsp-graph-online
-  const prefix = `/drive/root:/${remoteBaseDir}`;
+  const prefix = `/me/drive/root:/${remoteBaseDir}`;
 
   let key = fileOrFolderPath;
   if (fileOrFolderPath === "/" || fileOrFolderPath === "") {
@@ -424,14 +424,14 @@ export class FakeFsOnedriveFull extends FakeFs {
     if (this.vaultFolderExists) {
       // console.info(`already checked, /${this.remoteBaseDir} exist before`)
     } else {
-      const k = await this._getJson("/drive/root/children");
+      const k = await this._getJson("/me/drive/root/children");
       // console.debug(k);
       this.vaultFolderExists =
         (k.value as DriveItem[]).filter((x) => x.name === this.remoteBaseDir)
           .length > 0;
       if (!this.vaultFolderExists) {
         console.info(`remote does not have folder /${this.remoteBaseDir}`);
-        await this._postJson("/drive/root/children", {
+        await this._postJson("/me/drive/root/children", {
           name: `${this.remoteBaseDir}`,
           folder: {},
           "@microsoft.graph.conflictBehavior": "replace",
@@ -629,7 +629,7 @@ export class FakeFsOnedriveFull extends FakeFs {
     const NEXT_LINK_KEY = "@odata.nextLink";
     const DELTA_LINK_KEY = "@odata.deltaLink";
 
-    let res = await this._getJson(`/drive/root:/${this.remoteBaseDir}:/delta`);
+    let res = await this._getJson(`/me/drive/root:/${this.remoteBaseDir}:/delta`);
     const driveItems = res.value as DriveItem[];
     // console.debug(driveItems);
 
@@ -658,7 +658,7 @@ export class FakeFsOnedriveFull extends FakeFs {
     const DELTA_LINK_KEY = "@odata.deltaLink";
 
     const res = await this._getJson(
-      `/drive/root:/${this.remoteBaseDir}:/delta`
+      `/me/drive/root:/${this.remoteBaseDir}:/delta`
     );
     const driveItems = res.value as DriveItem[];
     // console.debug(driveItems);

--- a/src/fsOnedrive.ts
+++ b/src/fsOnedrive.ts
@@ -215,7 +215,7 @@ export const setConfigBySuccessfullAuthInplace = async (
 
 const getOnedrivePath = (fileOrFolderPath: string, remoteBaseDir: string) => {
   // https://docs.microsoft.com/en-us/onedrive/developer/rest-api/concepts/special-folders-appfolder?view=odsp-graph-online
-  const prefix = `/drive/special/approot:/${remoteBaseDir}`;
+  const prefix = `/me/drive/special/approot:/${remoteBaseDir}`;
 
   let key = fileOrFolderPath;
   if (fileOrFolderPath === "/" || fileOrFolderPath === "") {
@@ -578,14 +578,14 @@ export class FakeFsOnedrive extends FakeFs {
     if (this.vaultFolderExists) {
       // console.info(`already checked, /${this.remoteBaseDir} exist before`)
     } else {
-      const k = await this._getJson("/drive/special/approot/children");
+      const k = await this._getJson("/me/drive/special/approot/children");
       // console.debug(k);
       this.vaultFolderExists =
         (k.value as DriveItem[]).filter((x) => x.name === this.remoteBaseDir)
           .length > 0;
       if (!this.vaultFolderExists) {
         console.info(`remote does not have folder /${this.remoteBaseDir}`);
-        await this._postJson("/drive/special/approot/children", {
+        await this._postJson("/me/drive/special/approot/children", {
           name: `${this.remoteBaseDir}`,
           folder: {},
           "@microsoft.graph.conflictBehavior": "replace",
@@ -784,7 +784,7 @@ export class FakeFsOnedrive extends FakeFs {
     const DELTA_LINK_KEY = "@odata.deltaLink";
 
     let res = await this._getJson(
-      `/drive/special/approot:/${this.remoteBaseDir}:/delta`
+      `/me/drive/special/approot:/${this.remoteBaseDir}:/delta`
     );
     const driveItems = res.value as DriveItem[];
     // console.debug(driveItems);
@@ -814,7 +814,7 @@ export class FakeFsOnedrive extends FakeFs {
     const DELTA_LINK_KEY = "@odata.deltaLink";
 
     const res = await this._getJson(
-      `/drive/special/approot:/${this.remoteBaseDir}:/delta`
+      `/me/drive/special/approot:/${this.remoteBaseDir}:/delta`
     );
     const driveItems = res.value as DriveItem[];
     // console.debug(driveItems);
@@ -975,7 +975,7 @@ export class FakeFsOnedrive extends FakeFs {
       // ref: https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online
 
       // 1. create uploadSession
-      // uploadFile already starts with /drive/special/approot:/${remoteBaseDir}
+      // uploadFile already starts with /me/drive/special/approot:/${remoteBaseDir}
       let playload: any = {
         item: {
           "@microsoft.graph.conflictBehavior": "replace",


### PR DESCRIPTION
While experimenting with the remotely-save plugin for the first time, I create a vault and sync to OneDrive (for Personal). After that was working as expected, I went ahead and tried to sync with my OneDrive for Business.

After settings up the required Entra Enterprise App and Admin Grants for the MS Graph permissions (Ref: #11), I got 404 errors during connection "Check" and sync was failing. Probably related to #1030 

In OneDrive for Business, the "/drive" REST URI can represent more than just a single OneDrive. Adding the "/me" prefix - such that requests are always referencing the authenticated users OneDrive - fixes #1030

This change has no impact for "OneDrive for Personal" as "/drive" and "/me/drive" are always referring to the exact same drive instance.