### PR TITLE
Update services_connectable_or_not.md to include Scaleway Object Storace

### DIFF
--- a/docs/services_connectable_or_not.md
+++ b/docs/services_connectable_or_not.md
@@ -17,6 +17,7 @@ The list is for information purposes only.
 | [filebase](https://filebase.com/) | Yes | Yes | | |
 | QingStor 青云 | ? | ? | | |
 | [MinIO](https://min.io/) | Yes | Yes | | |
+| [Scaleway - Object Storage](https://www.scaleway.com/) | Yes | Yes | | |
 | Azure Blob Storage | Yes (PRO) | | | Yes (PRO) |
 | [WsgiDAV](https://github.com/mar10/wsgidav) | Yes | | Yes | |
 | [Nginx `ngx_http_dav_module`](http://nginx.org/en/docs/http/ngx_http_dav_module.html) | Yes | | Yes | |


### PR DESCRIPTION
Added Scaleway's Object storage to the list of supported storage provided as it is S3 compatible, and I have tested it to work.