### PR TITLE
Revise Cloudflare R2 setup instructions in README

### DIFF
--- a/docs/remote_services/s3_cloudflare_r2/README.md
+++ b/docs/remote_services/s3_cloudflare_r2/README.md
@@ -1,27 +1,40 @@
 # Cloudflare R2
+> [!IMPORTANT]
+> Though Cloudflare R2 provides a generous free tier, be aware that heavy usage may incur charges.
 
 ## Links
-
 <https://www.cloudflare.com/developer-platform/r2/>
 
 ## Steps
+> [!TIP]
+> Ensure you're using the latest version of the plugin. Improvements to connection testing for Cloudflare R2 are included in versions >= v0.3.29.
 
-1. **Be aware that it may cost you money.**
-2. Create a Cloudflare account and enable R2 feature. **Credit card info might be required by Cloudflare**, though Cloudflare provides generous free tier and zero egress fee.
-3. Create a bucket.
-   ![](./s3_cloudflare_r2_create_bucket.png)
-4. Create an Access Key with "Object Read & Write" permission, and add specify to your created bucket. During the creation, you will also get the auto-generated secret key, and the endpoint address.
-   ![](./s3_cloudflare_r2_create_api_token.png)
-5. In remotely-save setting page, input the address / bucket / access key / secret key. **Region being set to `us-east-1` is sufficient.** Enable "Bypass CORS", because usually that's what you want.
+1. **Configure Cloudflare R2 Storage**
+   1. Create a Cloudflare account
+      > **NOTE**: A credit card may be required.
+   3. Enable the Cloudflare R2 Storage feature.
+   1. [Create an R2 bucket](https://developers.cloudflare.com/r2/get-started/#2-create-a-bucket).  
+      <img src="./s3_cloudflare_r2_create_bucket.png" alt="create api token" width="600"/>
+   1. [Create an Access Token](https://developers.cloudflare.com/r2/api/tokens/)
+      > **NOTE**: A user-level API token is recommended as best practice, but you may choose account level if you prefer.
 
-   Click "check connectivity". (If you encounter an issue and sure the info are correct, please upgrade remotely-save to **version >= 0.3.29** and try again.)
+      1. Choose a descriptive name for the token (e.g. `yourname-obsidian`).
+      1. Choose `Object Read & Write` as the permission type.
+      1. Scope the access to your bucket only.
+      2. **KEEP THIS TAB OPEN FOR REFERENCE**  
+         <img src="./s3_cloudflare_r2_create_api_token.png" alt="create api token" width="600"/>
 
-   ![](./s3_cloudflare_r2_rs_settings.png)
 
-6. Sync!
+1. **Configure the Remotely Save plugin**
+   1. Go to the Remotely Save plugin settings.
+   1. Enter the bucket endpoint:  
+      **Endpoint**: `https://<endpoint>.r2.cloudflarestorage.com` or similar from your bucket properties overview.  
+      **Bucket**: `obsidian` or whatever bucket name you chose above.  
+      **Acccess Key**: `<access_key>` from your token creation tab.  
+      **Secret Key**: `secret_key` from your token creation tab.  
+      **Region**: `us-east-1`  
+   1. Click `Check Connectivity`.
+      > **NOTE**: A success message will indicate you a good configuration. If there is no success message, double check your settings and try again.  
+      <img src="./s3_cloudflare_r2_rs_settings.png" alt="create api token" width="600"/>
 
-## And Issue Related To "Check Connectivity"
-
-If you encounter an issue and sure the info are correct, please upgrade remotely-save to **version >= 0.3.29** and try again.
-
-Cloudflare doesn't allow `HeadBucket` for access keys with "Object Read & Write". So it may be possible that checking connectivity is not ok but actual syncing is ok. New version >= 0.3.29 of the plugin fix this problem by using `ListObjects` instead of `HeadBucket`.
+1. Sync!


### PR DESCRIPTION
Updated the README to clarify steps for configuring Cloudflare R2 and the Remotely Save plugin, including notes on account setup and permissions.