### PR TITLE
Preventing crashes on Android for S3 storage

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -51,13 +51,14 @@ esbuild
       "http",
       "https",
       "vm",
+      "node:url",
       // "process",
       // ...builtins
     ],
     inject: ["./esbuild.injecthelper.mjs"],
     format: "cjs",
     // watch: !prod, // no longer valid in esbuild 0.17
-    target: "es2016",
+    target: "es2020",
     logLevel: "info",
     sourcemap: prod ? false : "inline",
     treeShaking: true,

--- a/pro/src/fsAzureBlobStorage.ts
+++ b/pro/src/fsAzureBlobStorage.ts
@@ -78,7 +78,7 @@ const fromBlobPropsToEntity = (
 
   let hash: undefined | string = undefined;
   if (props.contentMD5 !== undefined) {
-    hash = arrayBufferToHex(props.contentMD5.buffer);
+    hash = arrayBufferToHex(props.contentMD5.buffer as ArrayBuffer);
   }
 
   const entity: Entity = {

--- a/pro/src/fsOnedriveFull.ts
+++ b/pro/src/fsOnedriveFull.ts
@@ -607,7 +607,7 @@ export class FakeFsOnedriveFull extends FakeFs {
     } else {
       const res = await fetch(theUrl, {
         method: "PUT",
-        body: payload.subarray(rangeStart, rangeEnd),
+        body: bufferToArrayBuffer(payload.subarray(rangeStart, rangeEnd)),
         headers: {
           "Content-Length": `${rangeEnd - rangeStart}`,
           "Content-Range": `bytes ${rangeStart}-${rangeEnd - 1}/${size}`,

--- a/src/baseTypesObs.ts
+++ b/src/baseTypesObs.ts
@@ -9,6 +9,7 @@ export const API_VER_REQURL = "0.13.26"; // desktop ver 0.13.26, iOS ver 1.1.1
 export const API_VER_REQURL_ANDROID = "0.14.6"; // Android ver 1.2.1
 export const API_VER_ENSURE_REQURL_OK = "1.0.0"; // always bypass CORS here
 
+// 20241227: On Android, requestUrl causes OOM for large files (Base64 encoding).
+// We disable it on Android to prevent crashes.
 export const VALID_REQURL =
-  (!Platform.isAndroidApp && requireApiVersion(API_VER_REQURL)) ||
-  (Platform.isAndroidApp && requireApiVersion(API_VER_REQURL_ANDROID));
+  (!Platform.isAndroidApp && requireApiVersion(API_VER_REQURL));

--- a/src/encryptOpenSSL.ts
+++ b/src/encryptOpenSSL.ts
@@ -24,7 +24,7 @@ const getKeyIVFromPassword = async (
   const k2 = await window.crypto.subtle.deriveBits(
     {
       name: "PBKDF2",
-      salt: salt,
+      salt: salt as unknown as BufferSource,
       iterations: rounds,
       hash: "SHA-256",
     },

--- a/src/fsOnedrive.ts
+++ b/src/fsOnedrive.ts
@@ -761,7 +761,7 @@ export class FakeFsOnedrive extends FakeFs {
     } else {
       const res = await fetch(theUrl, {
         method: "PUT",
-        body: payload.subarray(rangeStart, rangeEnd),
+        body: bufferToArrayBuffer(payload.subarray(rangeStart, rangeEnd)),
         headers: {
           "Content-Length": `${rangeEnd - rangeStart}`,
           "Content-Range": `bytes ${rangeStart}-${rangeEnd - 1}/${size}`,

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -89,8 +89,11 @@ export const mkdirpInVault = async (thePath: string, vault: Vault) => {
  */
 export const bufferToArrayBuffer = (
   b: Buffer | Uint8Array | ArrayBufferView
-) => {
-  return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+): ArrayBuffer => {
+  return b.buffer.slice(
+    b.byteOffset,
+    b.byteOffset + b.byteLength
+  ) as ArrayBuffer;
 };
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "strict": true,
     "allowJs": true,
     "noImplicitAny": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     // "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Removed Android from VALID_REQURL to force plugin to use the standard fetch or XMLHttpRequest API. It might still crash but only for very large files (> 50 or > 100 MB).