### PR TITLE
fix: 修复使用Google Drive同步时云端重复创建文件导致移动端无法同步最新改动的 bug

### DIFF
--- a/pro/src/fsGoogleDrive.ts
+++ b/pro/src/fsGoogleDrive.ts
@@ -710,18 +710,16 @@ export class FakeFsGoogleDrive extends FakeFs {
     const res1 = await fetch(
       `https://www.googleapis.com/drive/v3/files/${fileID}`,
       {
-        method: "PATCH",
+        method: "DELETE",
         headers: {
           Authorization: `Bearer ${await this._getAccessToken()}`,
         },
-        body: JSON.stringify({
-          trashed: true,
-        }),
       }
     );
-    if (res1.status !== 200) {
+    if (res1.status !== 204) {
       throw Error(`cannot rm ${key} using fileID=${fileID}`);
     }
+    delete this.keyToGDEntity[key];
   }
 
   async checkConnect(callbackFunc?: any): Promise<boolean> {

--- a/pro/src/sync.ts
+++ b/pro/src/sync.ts
@@ -426,7 +426,7 @@ const ensembleMixedEnties = async (
   if (
     Object.keys(finalMappings).filter((k) => !k.startsWith(configDir)).length -
       remoteMaySkipCountAndNotConfig ===
-      0 ||
+      0 &&
     localEntityList.filter((e) => !e.key?.startsWith(configDir)).length === 0
   ) {
     // Special checking:
@@ -1508,6 +1508,11 @@ const dispatchOperationToActualV3 = async (
     r.decision === "conflict_modified_then_keep_local"
   ) {
     // console.debug(`before upload in sync, r=${JSON.stringify(r, null, 2)}`);
+    // If remote file exists, delete it first to avoid Google Drive creating duplicate files
+    // when using POST to upload (POST always creates, never overwrites)
+    if (r.remote !== undefined) {
+      await fsEncrypt.rm(r.key);
+    }
     const mtimeCli = (await fsLocal.stat(r.key)).mtimeCli!;
     const { entity, content } = await copyFileOrFolder(
       r.key,


### PR DESCRIPTION
1. Google Drive rm 方法改用 DELETE 而非 PATCH trashed:true，避免文件移入回收站后 ID 仍被占用导致后续同步失败

2. local_is_modified_then_push 决策在上传前先调用 rm 删除远程旧文件，避免 Google Drive POST 上传创建重复文件

3. ensembleMixedEnties 空列表保护条件从; 改为; ，确保双方都为空才跳过 prevSync 处理