### PR TITLE
fix: 7 data-safety bugs — silent data loss, deletion resurrection, sync-aborting crash

### DIFF
--- a/pro/src/conflictLogic.ts
+++ b/pro/src/conflictLogic.ts
@@ -349,18 +349,31 @@ export async function tryDuplicateFile(
 ) {
   let key2 = getFileRenameForDup(key);
   let usable = false;
-  do {
+  // the dedup target must be free on BOTH sides: the duplicate is written to
+  // local AND remote, so checking only local can silently overwrite an
+  // unrelated file that already exists at key2 on the remote.
+  const existsOn = async (fs: FakeFs, k: string) => {
     try {
-      const s = await fsLocal.stat(key2);
-      if (s === null || s === undefined) {
-        throw Error(`not exist $${key2}`);
-      }
-      console.debug(`key2=${key2} exists, cannot use for new file`);
+      const s = await fs.stat(k);
+      return s !== null && s !== undefined;
+    } catch (e) {
+      // stat throwing means "not exist", exactly what we want
+      return false;
+    }
+  };
+  do {
+    const [onLocal, onRemote] = await Promise.all([
+      existsOn(fsLocal, key2),
+      existsOn(fsRemote, key2),
+    ]);
+    if (onLocal || onRemote) {
+      console.debug(
+        `key2=${key2} exists (local=${onLocal}, remote=${onRemote}), cannot use`
+      );
       key2 = getFileRenameForDup(key2);
       console.debug(`key2=${key2} is prepared for next try`);
-    } catch (e) {
-      // not exists, exactly what we want
-      console.debug(`key2=${key2} doesn't exist, usable for new file`);
+    } else {
+      console.debug(`key2=${key2} doesn't exist on either side, usable`);
       usable = true;
     }
   } while (!usable);

--- a/pro/src/fsGoogleDrive.ts
+++ b/pro/src/fsGoogleDrive.ts
@@ -283,11 +283,6 @@ export class FakeFsGoogleDrive extends FakeFs {
       concurrency: 5, // TODO: make it configurable?
       autoStart: true,
     });
-    queue.on("error", (error) => {
-      queue.pause();
-      queue.clear();
-      throw error;
-    });
 
     let parents = [
       {
@@ -297,7 +292,12 @@ export class FakeFsGoogleDrive extends FakeFs {
     ];
     while (parents.length !== 0) {
       const children: typeof parents = [];
-      for (const { id, folderPath } of parents) {
+      // NOTE: we MUST collect the promises returned by queue.add() and await
+      // them. A throw inside a p-queue "error" listener does NOT propagate to
+      // queue.onIdle(), so a failed folder listing would be silently swallowed
+      // and walk() would return a partial/empty remote list -> the sync engine
+      // then deletes local files that only "look" remotely deleted (data loss).
+      const tasks = parents.map(({ id, folderPath }) =>
         queue.add(async () => {
           const filesUnderFolder = await this._walkFolder(id, folderPath);
           for (const f of filesUnderFolder) {
@@ -309,17 +309,12 @@ export class FakeFsGoogleDrive extends FakeFs {
                 id: f.id,
                 folderPath: f.keyRaw,
               };
-              // console.debug(
-              //   `looping result of _walkFolder(${id},${folderPath}), adding child=${JSON.stringify(
-              //     child
-              //   )}`
-              // );
               children.push(child);
             }
           }
-        });
-      }
-      await queue.onIdle();
+        })
+      );
+      await Promise.all(tasks);
       parents = children;
     }
 

--- a/pro/src/fsYandexDisk.ts
+++ b/pro/src/fsYandexDisk.ts
@@ -324,18 +324,18 @@ export class FakeFsYandexDisk extends FakeFs {
       concurrency: 5, // TODO: make it configurable?
       autoStart: true,
     });
-    queue.on("error", (error) => {
-      queue.pause();
-      queue.clear();
-      throw error;
-    });
 
     const entities: Entity[] = [];
 
     let parents = ["/"];
     while (parents.length !== 0) {
       const children: typeof parents = [];
-      for (const p of parents) {
+      // NOTE: we MUST collect and await the queue.add() promises. A throw inside
+      // a p-queue "error" listener does NOT propagate to queue.onIdle(), so a
+      // failed subfolder listing would be swallowed and walk() would return a
+      // partial remote list -> the sync engine deletes local files that only
+      // "look" remotely deleted (data loss).
+      const tasks = parents.map((p) =>
         queue.add(async () => {
           const entitiesOfALevel = await this._walkFolder(p);
           for (const entity of entitiesOfALevel) {
@@ -344,9 +344,9 @@ export class FakeFsYandexDisk extends FakeFs {
               children.push(entity.keyRaw);
             }
           }
-        });
-      }
-      await queue.onIdle();
+        })
+      );
+      await Promise.all(tasks);
       parents = children;
     }
 

--- a/pro/src/sync.ts
+++ b/pro/src/sync.ts
@@ -1453,7 +1453,9 @@ const dispatchOperationToActualV3 = async (
 
       // but we might need to update content, because it's a new feature
       if (conflictAction === "smart_conflict") {
-        if (isMergable(r.local!)) {
+        // r.local can be undefined here (e.g. a remote-only, previously-synced
+        // file under push-only direction); isMergable(undefined) would throw
+        if (r.local !== undefined && isMergable(r.local)) {
           const k = await getFileContentHistoryByVaultAndProfile(
             db,
             vaultRandomID,

--- a/src/fsDropbox.ts
+++ b/src/fsDropbox.ts
@@ -730,9 +730,23 @@ export class FakeFsDropbox extends FakeFs {
           }),
         key // just a hint here
       );
-    } catch (err) {
+    } catch (err: any) {
+      // An already-absent remote file is fine: delete is idempotent.
+      // But EVERY other failure (network / 429-exhausted / permission) MUST
+      // propagate. Otherwise the caller treats the delete as successful and
+      // clears the prevSync record, so the still-present remote file is seen
+      // as "new" and re-downloaded on the next sync (deleted file resurrected).
+      const summary: string =
+        (err?.error?.error_summary as string) ?? `${err?.message ?? ""}`;
+      if (summary.includes("not_found")) {
+        console.warn(
+          `rm: remote ${remoteFileName} already absent, treating as deleted`
+        );
+        return;
+      }
       console.error("some error while deleting");
       console.error(err);
+      throw err;
     }
   }
 

--- a/src/fsS3.ts
+++ b/src/fsS3.ts
@@ -449,11 +449,6 @@ export class FakeFsS3 extends FakeFs {
       concurrency: partsConcurrency,
       autoStart: true,
     });
-    queueHead.on("error", (error) => {
-      queueHead.pause();
-      queueHead.clear();
-      throw error;
-    });
 
     let isTruncated = true;
     do {
@@ -471,27 +466,41 @@ export class FakeFsS3 extends FakeFs {
         // head requests of all objects, love it
         for (const content of rsp.Contents) {
           queueHead.add(async () => {
-            const rspHead = await this.s3Client.send(
-              new HeadObjectCommand({
-                Bucket: this.s3Config.s3BucketName,
-                Key: content.Key,
-              })
-            );
-            if (rspHead.$metadata.httpStatusCode !== 200) {
-              throw Error("some thing bad while heading single object!");
-            }
-            if (rspHead.Metadata === undefined) {
-              // pass
-            } else {
-              mtimeRecords[content.Key!] = Math.floor(
-                Number.parseFloat(
-                  rspHead.Metadata.mtime || rspHead.Metadata.MTime || "0"
-                )
+            try {
+              const rspHead = await this.s3Client.send(
+                new HeadObjectCommand({
+                  Bucket: this.s3Config.s3BucketName,
+                  Key: content.Key,
+                })
               );
-              ctimeRecords[content.Key!] = Math.floor(
-                Number.parseFloat(
-                  rspHead.Metadata.ctime || rspHead.Metadata.CTime || "0"
-                )
+              if (rspHead.$metadata.httpStatusCode !== 200) {
+                throw Error("some thing bad while heading single object!");
+              }
+              if (rspHead.Metadata === undefined) {
+                // pass
+              } else {
+                mtimeRecords[content.Key!] = Math.floor(
+                  Number.parseFloat(
+                    rspHead.Metadata.mtime || rspHead.Metadata.MTime || "0"
+                  )
+                );
+                ctimeRecords[content.Key!] = Math.floor(
+                  Number.parseFloat(
+                    rspHead.Metadata.ctime || rspHead.Metadata.CTime || "0"
+                  )
+                );
+              }
+            } catch (e) {
+              // A single failed HEAD only costs the accurate mtime for THIS
+              // object (it falls back to the coarser server LastModified).
+              // It must NOT abort the whole walk nor poison every other object:
+              // the previous code paused()+cleared() the queue and re-threw from
+              // the "error" listener, which p-queue swallows, silently degrading
+              // the mtime of all remaining objects.
+              console.warn(
+                `failed to HEAD ${content.Key} for accurate mtime, ` +
+                  `falling back to server mtime`,
+                e
               );
             }
           });

--- a/src/metadataOnRemote.ts
+++ b/src/metadataOnRemote.ts
@@ -41,7 +41,7 @@ export const serializeMetadataOnRemote = (x: MetadataOnRemote) => {
   const y = x;
 
   if (y["version"] === undefined) {
-    y["version"] === DEFAULT_VERSION_FOR_METADATAONREMOTE;
+    y["version"] = DEFAULT_VERSION_FOR_METADATAONREMOTE;
   }
   if (y["generatedWhen"] === undefined) {
     y["generatedWhen"] = Date.now();

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -450,7 +450,7 @@ export const isSpecialFolderNameToSkip = (
     ".svn",
     "node_modules",
     ".DS_Store",
-    "__MACOSX ",
+    "__MACOSX",
     "Icon\r", // https://superuser.com/questions/298785/icon-file-on-os-x-desktop
     "desktop.ini",
     "Desktop.ini",


### PR DESCRIPTION
## Summary

This PR fixes 7 bugs found during a systematic audit of the sync engine and remote backends. Each was verified against the code with a concrete failure path before fixing. The scariest ones are silent-data-loss paths that trigger on ordinary transient network errors — no attacker or unusual config needed.

## Fixes (one commit each, cherry-pickable)

### Data loss

1. **GDrive/Yandex `walk()` swallowed folder-listing errors → partial/empty listing → local files deleted** (`pro/src/fsGoogleDrive.ts`, `pro/src/fsYandexDisk.ts`)
   A `throw` inside a p-queue `error` listener does not propagate to `queue.onIdle()`. One transient 429/5xx during a listing made `walk()` resolve with a partial (often empty) remote list; the sync engine then classified every missing file as remotely deleted and deleted it locally. Fixed by collecting the `queue.add()` promises and `Promise.all`-ing them so failures genuinely reject.

2. **Dropbox `rm()` swallowed all delete failures → deleted files resurrected** (`src/fsDropbox.ts`)
   Every failure was caught and logged only, so the engine cleared the prevSync record as if the delete succeeded; the next sync saw the surviving remote file as new and re-downloaded it. Now only `not_found` (idempotent case) is tolerated; real failures propagate so the delete is retried next run.

3. **Conflict dup-rename could silently overwrite an unrelated remote file** (`pro/src/conflictLogic.ts`)
   `tryDuplicateFile` checked name availability only via `fsLocal.stat`, but both resolution paths write the chosen name to the remote too. A remote-only file at that name (e.g. created by another device, not yet pulled) was silently clobbered. Now both sides are probed until the candidate is free on both.

### Crash / sync-blocking

4. **`smart_conflict` + `incremental_push_only` crashed on a remote-only previously-synced file, aborting every sync** (`pro/src/sync.ts`)
   `isMergable(r.local!)` ran with `r.local === undefined` (decision branches 29/30), throwing a TypeError that aborted `doActualSync` via AggregateError — permanently, on every retry. Added an undefined guard.

### Correctness

5. **S3 accurate-mtime: one failed HEAD degraded every remaining object** (`src/fsS3.ts`)
   The queue error handler paused+cleared the HEAD queue and re-threw from inside the listener (swallowed by p-queue), so all remaining objects silently fell back to second-precision server mtime → spurious re-syncs. Each HEAD is now self-contained: a failure costs only that object's accurate mtime and is logged.

6. **`===` vs `=` typo: metadata `version` never persisted** (`src/metadataOnRemote.ts`)

7. **Trailing space in `"__MACOSX "` broke the special-folder skip** (`src/misc.ts`)
   The entry could never match a real `__MACOSX` folder, so it was synced whenever underscore-item syncing was enabled.

## Verification

- `npm test`: **72/72 passing** (includes the conflict/dedup/skip-name suites covering these files)
- `npx @biomejs/biome check` clean on all touched files
- `tsc -noEmit -skipLibCheck`: no new errors (the 19 pre-existing errors from dependency version drift are untouched)

Happy to sign the CLA if required, and to split or squash commits however you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKsZ6VNGBT4LU98Aas8qhx