### PR TITLE
fix(onedrive): callback mis-routing, silent hangs, token lifecycle, first-connect 400

### DIFF
--- a/src/fsOnedrive.ts
+++ b/src/fsOnedrive.ts
@@ -20,6 +20,7 @@ import {
 import { VALID_REQURL } from "./baseTypesObs";
 import { FakeFs } from "./fsAll";
 import { bufferToArrayBuffer } from "./misc";
+import { computeAccessTokenExpiresAtTime } from "./oauthLogic";
 
 const SCOPES = ["User.Read", "Files.ReadWrite.AppFolder", "offline_access"];
 const REDIRECT_URI = `obsidian://${COMMAND_CALLBACK_ONEDRIVE}`;
@@ -193,8 +194,11 @@ export const setConfigBySuccessfullAuthInplace = async (
 ) => {
   console.info("start updating local info of OneDrive token");
   config.accessToken = authRes.access_token;
-  config.accessTokenExpiresAtTime =
-    Date.now() + authRes.expires_in - 5 * 60 * 1000;
+  // expires_in is in seconds
+  config.accessTokenExpiresAtTime = computeAccessTokenExpiresAtTime(
+    Date.now(),
+    authRes.expires_in
+  );
   config.accessTokenExpiresInSeconds = authRes.expires_in;
   config.refreshToken = authRes.refresh_token!;
 
@@ -519,7 +523,11 @@ class MyAuthProvider implements AuthenticationProvider {
       this.onedriveConfig.refreshToken = r2.refresh_token!;
       this.onedriveConfig.accessTokenExpiresInSeconds = r2.expires_in;
       this.onedriveConfig.accessTokenExpiresAtTime =
-        currentTs + r2.expires_in * 1000 - 60 * 2 * 1000;
+        computeAccessTokenExpiresAtTime(currentTs, r2.expires_in);
+      // a successful refresh proves the credentials are alive;
+      // push the forced re-auth deadline out again
+      this.onedriveConfig.credentialsShouldBeDeletedAtTime =
+        currentTs + OAUTH2_FORCE_EXPIRE_MILLISECONDS;
       await this.saveUpdatedConfigFunc();
       console.info("Onedrive accessToken updated");
       return this.onedriveConfig.accessToken;
@@ -585,11 +593,27 @@ export class FakeFsOnedrive extends FakeFs {
           .length > 0;
       if (!this.vaultFolderExists) {
         console.info(`remote does not have folder /${this.remoteBaseDir}`);
-        await this._postJson("/drive/special/approot/children", {
-          name: `${this.remoteBaseDir}`,
-          folder: {},
-          "@microsoft.graph.conflictBehavior": "replace",
-        });
+        // POST /drive/special/approot/children returns 400 invalidRequest
+        // nowadays (also, "replace" was never valid for folders); create by
+        // item id instead. See upstream issue #1185.
+        const approot = await this._getJson("/drive/special/approot");
+        try {
+          await this._postJson(`/me/drive/items/${approot.id}/children`, {
+            name: `${this.remoteBaseDir}`,
+            folder: {},
+            "@microsoft.graph.conflictBehavior": "fail",
+          });
+        } catch (e) {
+          // "fail" errors if the folder appeared meanwhile; re-check
+          // before giving up
+          const k2 = await this._getJson("/drive/special/approot/children");
+          const exists = (k2.value as DriveItem[]).some(
+            (x) => x.name === this.remoteBaseDir
+          );
+          if (!exists) {
+            throw e;
+          }
+        }
         console.info(`remote folder /${this.remoteBaseDir} created`);
         this.vaultFolderExists = true;
       } else {

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -36,15 +36,14 @@
   "protocol_onedrive_connect_succ_revoke": "You've connected as user {{username}}. If you want to disconnect, click this button.",
   "protocol_onedrive_connect_fail": "Something went wrong from response from OneDrive. Maybe you rejected the auth?",
   "protocol_onedrive_connect_unknown": "Do not know how to deal with the callback: {{params}}",
+  "protocol_onedrive_no_pending_auth": "Received a OneDrive sign-in callback, but no OneDrive sign-in is pending in this vault ({{vaultName}}). Forwarding it to your other open vaults. If nothing happens, switch to the vault window where you clicked Auth, keep it focused, and try again.",
   "command_startsync": "start sync",
   "command_drynrun": "start sync (dry run only)",
   "command_exportsyncplans_1_only_change": "export sync plans (latest 1) (change part)",
   "command_exportsyncplans_1": "export sync plans (latest 1)",
   "command_exportsyncplans_5": "export sync plans (latest 5)",
   "command_exportsyncplans_all": "export sync plans (all)",
-
   "command_exportlogsindb": "export logs saved in db",
-
   "statusbar_sync_source_manual": "Manual: ",
   "statusbar_sync_source_dry": "Dry: ",
   "statusbar_sync_source_auto": "Auto: ",
@@ -64,7 +63,6 @@
   "statusbar_lastsync_label": "on {{date}}",
   "statusbar_lastsync_never": "Never Synced",
   "statusbar_lastsync_never_label": "Never Synced before",
-
   "modal_password_title": "Hold on and PLEASE READ ON...",
   "modal_password_shortdesc": "If the field is not empty, files would be encrypted locally before being uploaded.\nIf the field is empty, then files would be uploaded without encryption.",
   "modal_password_attn1": "Attention 1/5: The vault name is NOT encrypted. The plugin creates a folder with the vault name on some remote services.",
@@ -127,7 +125,6 @@
   "settings_encryptionmethod_desc": "Encryption method for E2E encryption. The RClone Crypt format is recommended, although it does not encrypt the path structure. OpenSSL enc is the legacy format of this plugin. <b>Both are not affliated with the official RClone and OpenSSL products or communities.</b> Attention: After switching encryption methods, you need to manually delete all original files from the remote location and re-sync to upload the encrypted files again. More info is available in the <a href='https://github.com/remotely-save/remotely-save/tree/master/docs/encryption'>online doc</a>.",
   "settings_encryptionmethod_rclone": "RClone Crypt (recommended)",
   "settings_encryptionmethod_openssl": "OpenSSL enc (legacy)",
-
   "settings_autorun": "Schedule For Auto Run",
   "settings_autorun_desc": "The plugin tries to schedule the running after every interval. Battery may be impacted.",
   "settings_autorun_notset": "(not set)",
@@ -234,7 +231,6 @@
   "settings_onedrive_emptyfile_desc": "OneDrive doesn't allow uploading empty file (even in its official website). Do you want to show up errors or silently skip the empty files?",
   "settings_onedrive_emptyfile_skip": "Skip",
   "settings_onedrive_emptyfile_error": "Error and abort",
-
   "settings_webdav": "Remote For Webdav",
   "settings_webdav_disclaimer1": "Disclaimer: The information is stored locally. Other malicious/harmful/faulty plugins may read the info. If you see any unintentional access to your webdav server, please immediately change the username and password.",
   "settings_webdav_cors_os": "Obsidian desktop>=0.13.25 or iOS>=1.1.1 or Android>=1.2.1 supports bypassing CORS locally. But you are using an old version, and you're suggested to upgrade Obsidian.",
@@ -257,7 +253,6 @@
   "settings_webdav_connect_succ": "Great! The webdav server can be accessed.",
   "settings_webdav_connect_fail": "The webdav server cannot be reached (possible to be any of address/username/password/authtype errors).",
   "settings_webdav_connect_fail_withcors": "The webdav server cannot be reached (possible to be any of address/username/password/authtype/CORS errors).",
-
   "settings_webdis": "Remote For Webdis",
   "settings_webdis_disclaimer1": "Disclaimer: This app is NOT an official Redis® Ltd / Redis® OSS / Webdis product. Redis is a registered trademark of Redis Ltd.",
   "settings_webdis_disclaimer2": "Disclaimer: The information is stored locally. Other malicious/harmful/faulty plugins may read the info. If you see any unintentional access to your Webdis server, please immediately change the username and password.",
@@ -306,7 +301,6 @@
   "settings_protectmodifypercentage_custom_desc": "custom",
   "settings_protectmodifypercentage_customfield": "Custom Abort Sync If Modification Above Percentage",
   "settings_protectmodifypercentage_customfield_desc": "You need to enter a number between 0 (inclusive) and 100 (inclusive). Float number is also allowed.",
-
   "setting_syncdirection": "Sync Direction (experimental)",
   "setting_syncdirection_desc": "<p>Which direction should the plugin sync to? Please be aware that only CHANGED files (based on time and size) are synced regardless any option.</p><ol><li>Bidirectional: Changes on both side are synced to the other side.</li><li>Incremental Push: Locally created or modifed files are copied to remote.</li><li>Incremental Pull: Remotely created or modifed files are copied to local.</li><li>Incremental Push And Delete: Locally created or modifed files are copied to remote, <strong>and local deletion operations are run on remote too.</strong></li><li>Incremental Pull And Delete: Remotely created or modifed files are copied to local, <strong>and remote deletion operations are run on local too.</strong></li></ol>",
   "setting_syncdirection_bidirectional_desc": "Bidirectional (default)",
@@ -314,7 +308,6 @@
   "setting_syncdirection_incremental_pull_only_desc": "Incremental Pull",
   "setting_syncdirection_incremental_push_and_delete_only_desc": "Incremental Push And Delete",
   "setting_syncdirection_incremental_pull_and_delete_only_desc": "Incremental Pull And Delete",
-
   "settings_enablemobilestatusbar": "Mobile Status Bar (experimental)",
   "settings_enablemobilestatusbar_desc": "By default Obsidian mobile hides status bar. But some users want to show it up. So here is a hack.",
   "settings_importexport": "Import and Export Partial Settings",
@@ -374,13 +367,11 @@
   "settings_resetcache_desc": "Reset local internal caches/databases (for debugging purposes). You would want to reload the plugin after resetting this. This option will not empty the {s3, password...} settings.",
   "settings_resetcache_button": "Reset",
   "settings_resetcache_notice": "Local internal cache/databases deleted. Please manually reload the plugin.",
-
   "syncalgov3_title": "Remotely Save has HUGE updates on the sync algorithm",
   "syncalgov3_texts": "Welcome to use Remotely Save!\nFrom this version, a new algorithm has been developed:\n<ul><li>More robust deletion sync,</li><li>minimal conflict handling,</li><li>no meta data uploaded any more,</li><li>deletion / modification protection,</li><li>backup mode</li><li>new encryption method</li><li>...</li></ul>\nStay tune for more! A full introduction is in the <a href='https://github.com/remotely-save/remotely-save/tree/master/docs/sync_algorithm/v3/intro.md'>doc website</a>.\nIf you agree to use this, please read and check two checkboxes then click the \"Agree\" button, and enjoy the plugin!\nIf you do not agree, please click the \"Do Not Agree\" button, the plugin will unload itself.\nAlso, please consider <a href='https://github.com/remotely-save/remotely-save'>visit the GitHub repo and star ⭐ it</a>! Or even <a href='https://github.com/remotely-save/donation'>buy me a coffee</a>. Your support is very important to me! Thanks!",
   "syncalgov3_checkbox_manual_backup": "I will backup my vault manually firstly.",
   "syncalgov3_checkbox_requiremultidevupdate": "I understand I need to update the plugin ACROSS ALL DEVICES to make them work properly.",
   "syncalgov3_button_agree": "Agree",
   "syncalgov3_button_disagree": "Do Not Agree",
-
   "menu_check_file_stat": "Check file stats"
 }

--- a/src/langs/zh_cn.json
+++ b/src/langs/zh_cn.json
@@ -36,6 +36,7 @@
   "protocol_onedrive_connect_succ_revoke": "您已作为用户 {{username}} 连接上了。如果您想取消连接，请点击此按钮。",
   "protocol_onedrive_connect_fail": "OneDrive 的回调请求有点异常。您是否拒绝了鉴权？",
   "protocol_onedrive_connect_unknown": "不知道如何处理此 callback：{{params}}",
+  "protocol_onedrive_no_pending_auth": "收到了 OneDrive 登录回调，但当前库（{{vaultName}}）没有正在进行的 OneDrive 登录。已尝试转发给其他打开的库。如果没有反应，请切换到点击了授权按钮的库窗口并保持其为活动窗口，然后重试。",
   "command_startsync": "开始同步（start sync）",
   "command_drynrun": "开始同步（空跑模式）（start sync (dry run only)）",
   "command_exportsyncplans_json": "导出同步计划为 json 格式（export sync plans in json format）",
@@ -44,7 +45,6 @@
   "command_exportsyncplans_5": "导出同步计划（最近 5 次）（export sync plans (latest 5)）",
   "command_exportsyncplans_all": "导出同步计划（所有）（export sync plans (all)）",
   "command_exportlogsindb": "从数据库导出终端日志（export logs saved in db）",
-
   "statusbar_sync_source_manual": "手动：",
   "statusbar_sync_source_dry": "空跑：",
   "statusbar_sync_source_auto": "自动：",
@@ -64,7 +64,6 @@
   "statusbar_lastsync_label": "日期：{{date}}",
   "statusbar_lastsync_never": "没触发过同步",
   "statusbar_lastsync_never_label": "没触发过同步",
-
   "modal_password_title": "稍等一下，请阅读下文：",
   "modal_password_shortdesc": "如果密码不是空的，那么文件会在上传之前，在本地先用此密码加密。\n如果密码是空的，那么文件会被非加密地上传。",
   "modal_password_attn1": "注意 1/5：库（Vault）名字是不会加密的！本插件会在一些远程存储里创建一个和库名字有着同名的文件夹。",
@@ -233,7 +232,6 @@
   "settings_onedrive_emptyfile_desc": "OneDrive 不允许上传空文件（即使官网也是不允许的）。那么你想跳过空文件还是返回错误？",
   "settings_onedrive_emptyfile_skip": "跳过",
   "settings_onedrive_emptyfile_error": "返回错误和中断",
-
   "settings_webdav": "Webdav 设置",
   "settings_webdav_disclaimer1": "声明：您所输入的信息存储于本地。其它有害的或者出错的插件，是有可能读取到这些信息的。如果您发现了 Webdav 服务器有不符合预期的访问，请立刻修改用户名和密码。",
   "settings_webdav_cors_os": "Obsidian 桌面版>=0.13.25 或 iOS>=1.1.1 或 Android>=1.2.1 支持跳过 CORS 设置。但您正在使用旧版，建议升级。",
@@ -256,7 +254,6 @@
   "settings_webdav_connect_succ": "很好！可以连接上 Webdav 服务器。",
   "settings_webdav_connect_fail": "无法连接上 Webdav 服务器。（可能是地址/账号/密码/鉴权类型等错误。）",
   "settings_webdav_connect_fail_withcors": "无法连接上 Webdav 服务器。（可能是地址/账号/密码/鉴权类型/CORS 等错误。）",
-
   "settings_webdis": "Webdis 设置",
   "settings_webdis_disclaimer1": "声明：此插件不是 Redis® Ltd 或 Redis® 软件或 Wedis 的官方产品。Redis 是 Redis Ltd 的注册商标。",
   "settings_webdis_disclaimer2": "声明：您所输入的信息存储于本地。其它有害的或者出错的插件，是有可能读取到这些信息的。如果您发现了 Webdis 服务器有不符合预期的访问，请立刻修改用户名和密码。",
@@ -305,7 +302,6 @@
   "settings_protectmodifypercentage_custom_desc": "自定义",
   "settings_protectmodifypercentage_customfield": "如果修改超过自定义百分比则中止同步",
   "settings_protectmodifypercentage_customfield_desc": "您需要输入 0（含）~ 100（含）的数字。小数也是可以的。",
-
   "setting_syncdirection": "同步方向（实验性质）",
   "setting_syncdirection_desc": "<p>W插件应该向哪里同步？注意每个选项都是只有修改了的文件（基于修改时间和大小判断）才会触发同步动作。</p><ol><li>双向同步：一边的变动会同步到另一边。</li><li>增量推送：本地创建或修改的文件会复制到远端。</li><li>增量拉取：远端创建或修改的文件会复制到本地。</li><li>增量推送带删除：本地创建或修改的文件会复制到远端，<strong>本地的删除也会在远端运行。</strong></li><li>增量拉取带删除：远端创建或修改的文件会复制到本地，<strong>远端的删除也会在本地运行。</strong></li></ol>",
   "setting_syncdirection_bidirectional_desc": "双向同步（默认）",
@@ -313,7 +309,6 @@
   "setting_syncdirection_incremental_pull_only_desc": "增量拉取",
   "setting_syncdirection_incremental_push_and_delete_only_desc": "增量推送带删除",
   "setting_syncdirection_incremental_pull_and_delete_only_desc": "增量拉取带删除",
-
   "settings_enablemobilestatusbar": "手机的状态栏（实验性质）",
   "settings_enablemobilestatusbar_desc": "Obsidian 手机版默认隐藏了状态栏。有些用户希望展示它。这里提供了设置选项。",
   "settings_importexport": "导入导出部分设置",
@@ -373,13 +368,11 @@
   "settings_resetcache_desc": "（出于调试原因）重设本地缓存和数据库。您需要在重设之后重新载入此插件。本重设不会删除 s3，密码……等设定。",
   "settings_resetcache_button": "重设",
   "settings_resetcache_notice": "本地同步缓存和数据库已被删除。请手动重新载入此插件。",
-
   "syncalgov3_title": "Remotely Save 的同步算法有重大更新",
   "syncalgov3_texts": "欢迎使用 Remotely Save！\n从这个版本开始，插件更新了同步算法：\n<ul><li>更稳健的删除同步</li><li>引入冲突处理</li><li>避免上传元数据</li><li>修改删除保护</li><li>备份模式</li><li>新的加密方式</li><li>……</li></ul>\n敬请期待更多更新！详细介绍请参阅<a href='https://github.com/remotely-save/remotely-save/tree/master/docs/sync_algorithm/v3/intro.md'>文档网站</a>。\n如果您同意使用新版本，请阅读和勾选两个勾选框，然后点击“同意”按钮，开始使用插件吧！\n如果您不同意，请点击“不同意”按钮，插件将自动停止运行（unload）。\n此外，请考虑<a href='https://github.com/remotely-save/remotely-save'>访问 GitHub 页面然后点赞 ⭐</a>！您的支持对我十分重要！谢谢！",
   "syncalgov3_checkbox_manual_backup": "我将会首先手动备份我的库（Vault）。",
   "syncalgov3_checkbox_requiremultidevupdate": "我理解，我需要在所有设备上都更新此插件使之正常运行。",
   "syncalgov3_button_agree": "同意",
   "syncalgov3_button_disagree": "不同意",
-
   "menu_check_file_stat": "查看文件属性"
 }

--- a/src/langs/zh_tw.json
+++ b/src/langs/zh_tw.json
@@ -36,6 +36,7 @@
   "protocol_onedrive_connect_succ_revoke": "您已作為使用者 {{username}} 連線上了。如果您想取消連線，請點選此按鈕。",
   "protocol_onedrive_connect_fail": "OneDrive 的回撥請求有點異常。您是否拒絕了鑑權？",
   "protocol_onedrive_connect_unknown": "不知道如何處理此 callback：{{params}}",
+  "protocol_onedrive_no_pending_auth": "收到了 OneDrive 登入回調，但目前的儲存庫（{{vaultName}}）沒有正在進行的 OneDrive 登入。已嘗試轉發給其他開啟的儲存庫。如果沒有反應，請切換到點擊了授權按鈕的儲存庫視窗並保持其為使用中視窗，然後重試。",
   "command_startsync": "開始同步（start sync）",
   "command_drynrun": "開始同步（空跑模式）（start sync (dry run only)）",
   "command_exportsyncplans_1_only_change": "匯出同步計劃（最近 1 次）（僅修改部分）（export sync plans (latest 1) (change part)）",
@@ -43,7 +44,6 @@
   "command_exportsyncplans_5": "匯出同步計劃（最近 5 次）（export sync plans (latest 5)）",
   "command_exportsyncplans_all": "匯出同步計劃（所有）（export sync plans (all)）",
   "command_exportlogsindb": "從資料庫匯出終端日誌（export logs saved in db）",
-
   "statusbar_sync_source_manual": "手動：",
   "statusbar_sync_source_dry": "空跑：",
   "statusbar_sync_source_auto": "自動：",
@@ -63,7 +63,6 @@
   "statusbar_lastsync_label": "日期：{{date}}",
   "statusbar_lastsync_never": "沒觸發過同步",
   "statusbar_lastsync_never_label": "沒觸發過同步",
-
   "modal_password_title": "稍等一下，請閱讀下文：",
   "modal_password_shortdesc": "如果密碼不是空的，那麼檔案會在上傳之前，在本地先用此密碼加密。\n如果密碼是空的，那麼檔案會被非加密地上傳。",
   "modal_password_attn1": "注意 1/5：儲存庫（Vault）名字是不會加密的！本外掛會在一些遠端儲存裡建立一個和庫名字有著同名的資料夾。",
@@ -232,7 +231,6 @@
   "settings_onedrive_emptyfile_desc": "OneDrive 不允許上傳空檔案（即使官網也是不允許的）。那麼你想跳過空檔案還是返回錯誤？",
   "settings_onedrive_emptyfile_skip": "跳過",
   "settings_onedrive_emptyfile_error": "返回錯誤和中斷",
-
   "settings_webdav": "Webdav 設定",
   "settings_webdav_disclaimer1": "宣告：您所輸入的資訊儲存於本地。其它有害的或者出錯的外掛，是有可能讀取到這些資訊的。如果您發現了 Webdav 伺服器有不符合預期的訪問，請立刻修改使用者名稱和密碼。",
   "settings_webdav_cors_os": "Obsidian 桌面版>=0.13.25 或 iOS>=1.1.1 或 Android>=1.1.1 支援跳過 CORS 設定。但您正在使用舊版，建議升級。",
@@ -255,7 +253,6 @@
   "settings_webdav_connect_succ": "很好！可以連線上 Webdav 伺服器。",
   "settings_webdav_connect_fail": "無法連線上 Webdav 伺服器。（可能是地址/賬號/密碼/鑑權型別等錯誤。）",
   "settings_webdav_connect_fail_withcors": "無法連線上 Webdav 伺服器。（可能是地址/賬號/密碼/鑑權型別/CORS 等錯誤。）",
-
   "settings_webdis": "Webdis 設置",
   "settings_webdis_disclaimer1": "聲明：此插件不是 Redis® Ltd 或 Redis® 軟件或 Wedis 的官方產品。Redis 是 Redis Ltd 的註冊商標。",
   "settings_webdis_disclaimer2": "聲明：您所輸入的信息存儲於本地。其它有害的或者出錯的插件，是有可能讀取到這些信息的。如果您發現了 Webdis 服務器有不符合預期的訪問，請立刻修改用戶名和密碼。",
@@ -304,7 +301,6 @@
   "settings_protectmodifypercentage_custom_desc": "自定義",
   "settings_protectmodifypercentage_customfield": "如果修改超過自定義百分比則中止同步",
   "settings_protectmodifypercentage_customfield_desc": "您需要輸入 0（含）~ 100（含）的數字。小數也是可以的。",
-
   "setting_syncdirection": "同步方向（實驗性質）",
   "setting_syncdirection_desc": "<p>W外掛應該向哪裡同步？注意每個選項都是隻有修改了的檔案（基於修改時間和大小判斷）才會觸發同步動作。</p><ol><li>雙向同步：一邊的變動會同步到另一邊。</li><li>增量推送：本地建立或修改的檔案會複製到遠端。</li><li>增量拉取：遠端建立或修改的檔案會複製到本地。</li><li>增量推送帶刪除：本地建立或修改的檔案會複製到遠端，<strong>本地的刪除也會在遠端執行。</strong></li><li>增量拉取帶刪除：遠端建立或修改的檔案會複製到本地，<strong>遠端的刪除也會在本地執行。</strong></li></ol>",
   "setting_syncdirection_bidirectional_desc": "雙向同步（預設）",
@@ -312,7 +308,6 @@
   "setting_syncdirection_incremental_pull_only_desc": "增量拉取",
   "setting_syncdirection_incremental_push_and_delete_only_desc": "增量推送帶刪除",
   "setting_syncdirection_incremental_pull_and_delete_only_desc": "增量拉取帶刪除",
-
   "settings_enablemobilestatusbar": "手機的狀態列（實驗性質）",
   "settings_enablemobilestatusbar_desc": "Obsidian 手機版預設隱藏了狀態列。有些使用者希望展示它。這裡提供了設定選項。",
   "settings_importexport": "匯入匯出部分設定",
@@ -372,13 +367,11 @@
   "settings_resetcache_desc": "（出於除錯原因）重設本地快取和資料庫。您需要在重設之後重新載入此外掛。本重設不會刪除 s3，密碼……等設定。",
   "settings_resetcache_button": "重設",
   "settings_resetcache_notice": "本地同步快取和資料庫已被刪除。請手動重新載入此外掛。",
-
   "syncalgov3_title": "Remotely Save 的同步演算法有重大更新",
   "syncalgov3_texts": "歡迎使用 Remotely Save！\n從這個版本開始，外掛更新了同步演算法：\n<ul><li>更穩健的刪除同步</li><li>引入衝突處理</li><li>避免上傳元資料</li><li>修改刪除保護</li><li>備份模式</li><li>新的加密方式</li><li>……</li></ul>\n敬請期待更多更新！詳細介紹請參閱<a href='https://github.com/remotely-save/remotely-save/tree/master/docs/sync_algorithm/v3/intro.md'>文件網站</a>。\n如果您同意使用新版本，請閱讀和勾選兩個勾選框，然後點選“同意”按鈕，開始使用外掛吧！\n如果您不同意，請點選“不同意”按鈕，外掛將自動停止執行（unload）。\n此外，請考慮<a href='https://github.com/remotely-save/remotely-save'>訪問 GitHub 頁面然後點贊 ⭐</a>！您的支援對我十分重要！謝謝！",
   "syncalgov3_checkbox_manual_backup": "我將會首先手動備份我的庫（Vault）。",
   "syncalgov3_checkbox_requiremultidevupdate": "我理解，我需要在所有裝置上都更新此外掛使之正常執行。",
   "syncalgov3_button_agree": "同意",
   "syncalgov3_button_disagree": "不同意",
-
   "menu_check_file_stat": "檢視檔案屬性"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,7 +87,9 @@ import { FakeFsLocal } from "./fsLocal";
 import {
   type AccessCodeResponseSuccessfulType as AccessCodeResponseSuccessfulTypeOnedrive,
   DEFAULT_ONEDRIVE_CONFIG,
+  FakeFsOnedrive,
   sendAuthReq as sendAuthReqOnedrive,
+  sendRefreshTokenReq as sendRefreshTokenReqOnedrive,
   setConfigBySuccessfullAuthInplace as setConfigBySuccessfullAuthInplaceOnedrive,
 } from "./fsOnedrive";
 import { DEFAULT_S3_CONFIG } from "./fsS3";
@@ -108,6 +110,10 @@ import {
   upsertPluginVersionByVault,
 } from "./localdb";
 import { changeMobileStatusBar } from "./misc";
+import {
+  decideCredentialAction,
+  decideOnedriveCallbackAction,
+} from "./oauthLogic";
 import { DEFAULT_PROFILER_CONFIG, Profiler } from "./profiler";
 import { RemotelySaveSettingTab } from "./settings";
 import { SyncAlgoV3Modal } from "./syncAlgoV3Notice";
@@ -220,6 +226,7 @@ export default class RemotelySavePlugin extends Plugin {
   hasPendingSyncOnSave!: boolean;
   statusBarElement!: HTMLSpanElement;
   oauth2Info!: OAuth2Info;
+  oauthOnedriveChannel?: BroadcastChannel;
   currLogLevel!: string;
   currSyncMsg?: string;
   syncRibbon?: HTMLElement;
@@ -703,86 +710,29 @@ export default class RemotelySavePlugin extends Plugin {
     this.registerObsidianProtocolHandler(
       COMMAND_CALLBACK_ONEDRIVE,
       async (inputParams) => {
-        if (
-          inputParams.code !== undefined &&
-          this.oauth2Info?.verifier !== undefined
-        ) {
-          if (this.oauth2Info.helperModal !== undefined) {
-            const k = this.oauth2Info.helperModal.contentEl;
-            k.empty();
-
-            t("protocol_onedrive_connecting")
-              .split("\n")
-              .forEach((val) => {
-                k.createEl("p", {
-                  text: val,
-                });
-              });
-          }
-
-          const rsp = await sendAuthReqOnedrive(
-            this.settings.onedrive.clientID,
-            this.settings.onedrive.authority,
-            inputParams.code,
-            this.oauth2Info.verifier,
-            async (e: any) => {
-              new Notice(t("protocol_onedrive_connect_fail"));
-              new Notice(`${e}`);
-              return; // throw?
-            }
-          );
-
-          if ((rsp as any).error !== undefined) {
-            new Notice(`${JSON.stringify(rsp)}`);
-            throw Error(`${JSON.stringify(rsp)}`);
-          }
-
-          const self = this;
-          setConfigBySuccessfullAuthInplaceOnedrive(
-            this.settings.onedrive,
-            rsp as AccessCodeResponseSuccessfulTypeOnedrive,
-            () => self.saveSettings()
-          );
-
-          const client = getClient(
-            this.settings,
-            this.app.vault.getName(),
-            () => self.saveSettings()
-          );
-          this.settings.onedrive.username = await client.getUserDisplayName();
-          await this.saveSettings();
-
-          this.oauth2Info.verifier = ""; // reset it
-          this.oauth2Info.helperModal?.close(); // close it
-          this.oauth2Info.helperModal = undefined;
-
-          this.oauth2Info.authDiv?.toggleClass(
-            "onedrive-auth-button-hide",
-            this.settings.onedrive.username !== ""
-          );
-          this.oauth2Info.authDiv = undefined;
-
-          this.oauth2Info.revokeAuthSetting?.setDesc(
-            t("protocol_onedrive_connect_succ_revoke", {
-              username: this.settings.onedrive.username,
-            })
-          );
-          this.oauth2Info.revokeAuthSetting = undefined;
-          this.oauth2Info.revokeDiv?.toggleClass(
-            "onedrive-revoke-auth-button-hide",
-            this.settings.onedrive.username === ""
-          );
-          this.oauth2Info.revokeDiv = undefined;
-        } else {
-          new Notice(t("protocol_onedrive_connect_fail"));
-          throw Error(
-            t("protocol_onedrive_connect_unknown", {
-              params: JSON.stringify(inputParams),
-            })
-          );
-        }
+        await this.handleOnedriveAuthCallback(inputParams, t);
       }
     );
+
+    // obsidian:// callbacks are delivered to only one window. With several
+    // vault windows open, the auth code can land in a window that never
+    // started an auth; that window forwards the params here so the window
+    // that IS waiting can complete the exchange.
+    if (typeof BroadcastChannel !== "undefined") {
+      this.oauthOnedriveChannel = new BroadcastChannel(
+        "remotely-save-oauth-onedrive"
+      );
+      this.oauthOnedriveChannel.onmessage = async (ev: MessageEvent) => {
+        const params = ev?.data?.params;
+        if (params?.code !== undefined && !!this.oauth2Info?.verifier) {
+          await this.handleOnedriveAuthCallback(params, t);
+        }
+      };
+      this.register(() => {
+        this.oauthOnedriveChannel?.close();
+        this.oauthOnedriveChannel = undefined;
+      });
+    }
 
     this.registerObsidianProtocolHandler(
       COMMAND_CALLBACK_ONEDRIVEFULL,
@@ -1529,6 +1479,120 @@ export default class RemotelySavePlugin extends Plugin {
     }
   }
 
+  async handleOnedriveAuthCallback(
+    inputParams: Record<string, string>,
+    t: (x: TransItemType, vars?: any) => string
+  ) {
+    const decision = decideOnedriveCallbackAction(
+      inputParams,
+      this.oauth2Info?.verifier
+    );
+
+    if (decision.kind === "forward") {
+      // no auth is pending in this vault's window -- consuming the one-time
+      // code here would burn it; hand it to the other open windows instead
+      this.oauthOnedriveChannel?.postMessage({ params: { ...inputParams } });
+      new Notice(
+        t("protocol_onedrive_no_pending_auth", {
+          vaultName: this.app.vault.getName(),
+        }),
+        10000
+      );
+      return;
+    }
+
+    if (decision.kind === "denied") {
+      new Notice(t("protocol_onedrive_connect_fail"));
+      new Notice(decision.errorDescription);
+      return;
+    }
+
+    if (decision.kind === "invalid") {
+      new Notice(t("protocol_onedrive_connect_fail"));
+      throw Error(
+        t("protocol_onedrive_connect_unknown", {
+          params: JSON.stringify(inputParams),
+        })
+      );
+    }
+
+    try {
+      if (this.oauth2Info.helperModal !== undefined) {
+        const k = this.oauth2Info.helperModal.contentEl;
+        k.empty();
+
+        t("protocol_onedrive_connecting")
+          .split("\n")
+          .forEach((val) => {
+            k.createEl("p", {
+              text: val,
+            });
+          });
+      }
+
+      const rsp = await sendAuthReqOnedrive(
+        this.settings.onedrive.clientID,
+        this.settings.onedrive.authority,
+        inputParams.code,
+        this.oauth2Info.verifier!,
+        async (e: any) => {
+          console.error(e);
+        }
+      );
+
+      if (rsp === undefined || (rsp as any).error !== undefined) {
+        throw Error(`${JSON.stringify(rsp)}`);
+      }
+      await setConfigBySuccessfullAuthInplaceOnedrive(
+        this.settings.onedrive,
+        rsp as AccessCodeResponseSuccessfulTypeOnedrive,
+        () => this.saveSettings()
+      );
+
+      // always use a OneDrive client here: the currently selected service
+      // type may be a different remote entirely
+      const client = new FakeFsOnedrive(
+        this.settings.onedrive,
+        this.app.vault.getName(),
+        () => this.saveSettings()
+      );
+      this.settings.onedrive.username = await client.getUserDisplayName();
+      await this.saveSettings();
+
+      this.oauth2Info.verifier = ""; // reset it
+      this.oauth2Info.helperModal?.close(); // close it
+      this.oauth2Info.helperModal = undefined;
+
+      this.oauth2Info.authDiv?.toggleClass(
+        "onedrive-auth-button-hide",
+        this.settings.onedrive.username !== ""
+      );
+      this.oauth2Info.authDiv = undefined;
+
+      this.oauth2Info.revokeAuthSetting?.setDesc(
+        t("protocol_onedrive_connect_succ_revoke", {
+          username: this.settings.onedrive.username,
+        })
+      );
+      this.oauth2Info.revokeAuthSetting = undefined;
+      this.oauth2Info.revokeDiv?.toggleClass(
+        "onedrive-revoke-auth-button-hide",
+        this.settings.onedrive.username === ""
+      );
+      this.oauth2Info.revokeDiv = undefined;
+    } catch (e: any) {
+      // surface the error instead of hanging the "connecting" modal forever
+      console.error(e);
+      new Notice(t("protocol_onedrive_connect_fail"));
+      new Notice(`${e}`, 10000);
+      const k = this.oauth2Info?.helperModal?.contentEl;
+      if (k !== undefined) {
+        k.empty();
+        k.createEl("p", { text: `${e}` });
+      }
+    }
+  }
+
   async checkIfOauthExpires() {
     let needSave = false;
     const current = Date.now();
@@ -1568,13 +1632,45 @@ export default class RemotelySavePlugin extends Plugin {
 
     let onedriveExpired = false;
     if (
-      this.settings.onedrive.refreshToken !== "" &&
-      current >= this.settings!.onedrive!.credentialsShouldBeDeletedAtTime!
+      decideCredentialAction({
+        hasRefreshToken: this.settings.onedrive.refreshToken !== "",
+        deleteAtTimeMs:
+          this.settings.onedrive.credentialsShouldBeDeletedAtTime ?? 0,
+        nowMs: current,
+      }) === "refresh-or-prompt"
     ) {
-      console.warn(`onedrive expired`);
-      onedriveExpired = true;
-      this.settings.onedrive = cloneDeep(DEFAULT_ONEDRIVE_CONFIG);
-      needSave = true;
+      // the deadline passed, but the refresh token may well still be valid;
+      // try it before bothering the user -- never wipe on a timer
+      try {
+        const r = await sendRefreshTokenReqOnedrive(
+          this.settings.onedrive.clientID,
+          this.settings.onedrive.authority,
+          this.settings.onedrive.refreshToken
+        );
+        if ((r as any).error !== undefined) {
+          throw Error(`${(r as any).error_description ?? (r as any).error}`);
+        }
+        await setConfigBySuccessfullAuthInplaceOnedrive(
+          this.settings.onedrive,
+          r as AccessCodeResponseSuccessfulTypeOnedrive,
+          () => undefined
+        );
+        console.info(
+          "onedrive: refresh succeeded after the deadline, credentials kept"
+        );
+        needSave = true;
+      } catch (e) {
+        console.warn(`onedrive: token refresh failed, re-auth needed: ${e}`);
+        onedriveExpired = true;
+        // clear only the auth fields; keep the user's other OneDrive settings
+        this.settings.onedrive.accessToken = "";
+        this.settings.onedrive.refreshToken = "";
+        this.settings.onedrive.accessTokenExpiresInSeconds = 0;
+        this.settings.onedrive.accessTokenExpiresAtTime = 0;
+        this.settings.onedrive.credentialsShouldBeDeletedAtTime = 0;
+        this.settings.onedrive.username = "";
+        needSave = true;
+      }
     }
 
     let onedriveFullExpired = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1530,18 +1530,27 @@ export default class RemotelySavePlugin extends Plugin {
           });
       }
 
+      let authError: any = undefined;
       const rsp = await sendAuthReqOnedrive(
         this.settings.onedrive.clientID,
         this.settings.onedrive.authority,
         inputParams.code,
         this.oauth2Info.verifier!,
         async (e: any) => {
+          authError = e;
           console.error(e);
         }
       );
 
       if (rsp === undefined || (rsp as any).error !== undefined) {
-        throw Error(`${JSON.stringify(rsp)}`);
+        throw Error(
+          `OneDrive token exchange failed: ${
+            (rsp as any)?.error_description ??
+            (rsp as any)?.error ??
+            authError ??
+            "unknown error"
+          }`
+        );
       }
       await setConfigBySuccessfullAuthInplaceOnedrive(
         this.settings.onedrive,

--- a/src/oauthLogic.ts
+++ b/src/oauthLogic.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure decision logic for the OAuth flows.
+ * Deliberately free of "obsidian" imports so it can be unit tested.
+ */
+
+const ACCESS_TOKEN_SAFETY_MARGIN_MS = 5 * 60 * 1000;
+
+/**
+ * expires_in from the token endpoint is in SECONDS.
+ * Returns an absolute epoch-ms deadline, with a safety margin, that is
+ * always in the future for a token that has any lifetime at all.
+ */
+export const computeAccessTokenExpiresAtTime = (
+  nowMs: number,
+  expiresInSeconds: number
+): number => {
+  const lifetimeMs = expiresInSeconds * 1000;
+  return Math.max(
+    nowMs + lifetimeMs - ACCESS_TOKEN_SAFETY_MARGIN_MS,
+    nowMs + Math.floor(lifetimeMs / 2)
+  );
+};
+
+export type OnedriveCallbackAction =
+  | { kind: "process" }
+  | { kind: "forward" }
+  | { kind: "denied"; errorDescription: string }
+  | { kind: "invalid" };
+
+/**
+ * Obsidian delivers obsidian:// callbacks to a single window. With several
+ * vault windows open, the auth code can land in a vault that never started
+ * an auth. That vault must NOT consume the one-time code ("forward" instead).
+ */
+export const decideOnedriveCallbackAction = (
+  params: { code?: string; error?: string; error_description?: string },
+  verifier: string | undefined
+): OnedriveCallbackAction => {
+  if (params.error !== undefined) {
+    return {
+      kind: "denied",
+      errorDescription: params.error_description ?? params.error,
+    };
+  }
+  if (params.code !== undefined) {
+    if (verifier !== undefined && verifier !== "") {
+      return { kind: "process" };
+    }
+    return { kind: "forward" };
+  }
+  return { kind: "invalid" };
+};
+
+export type CredentialAction = "keep" | "refresh-or-prompt";
+
+/**
+ * What to do with stored OAuth credentials at startup. Never returns a
+ * "wipe": a possibly-still-valid refresh token must not be deleted on a
+ * timer; try to use it, and only involve the user if the refresh fails.
+ */
+export const decideCredentialAction = (input: {
+  hasRefreshToken: boolean;
+  deleteAtTimeMs: number;
+  nowMs: number;
+}): CredentialAction => {
+  if (!input.hasRefreshToken) {
+    return "keep";
+  }
+  if (input.nowMs < input.deleteAtTimeMs) {
+    return "keep";
+  }
+  return "refresh-or-prompt";
+};

--- a/tests/oauthLogic.test.ts
+++ b/tests/oauthLogic.test.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from "assert";
+import {
+  computeAccessTokenExpiresAtTime,
+  decideCredentialAction,
+  decideOnedriveCallbackAction,
+} from "../src/oauthLogic";
+
+describe("computeAccessTokenExpiresAtTime", () => {
+  it("treats expires_in as seconds, not milliseconds", () => {
+    const now = 1_000_000;
+    // 3600 s lifetime minus the 5-minute safety margin
+    assert.equal(
+      computeAccessTokenExpiresAtTime(now, 3600),
+      now + 3600 * 1000 - 5 * 60 * 1000
+    );
+  });
+
+  it("never returns a time in the past for short-lived tokens", () => {
+    const now = 1_000_000;
+    // 60 s lifetime is shorter than the margin; must still be in the future
+    const at = computeAccessTokenExpiresAtTime(now, 60);
+    assert.ok(at > now, `expected ${at} > ${now}`);
+  });
+});
+
+describe("decideOnedriveCallbackAction", () => {
+  it("processes when a code arrives and a verifier is pending", () => {
+    assert.deepEqual(
+      decideOnedriveCallbackAction({ code: "abc" }, "some-verifier"),
+      { kind: "process" }
+    );
+  });
+
+  it("forwards instead of consuming the code when no auth is pending", () => {
+    // an empty-string verifier means no auth in progress in this vault;
+    // consuming the one-time code here would burn it (the multi-window bug)
+    assert.deepEqual(decideOnedriveCallbackAction({ code: "abc" }, ""), {
+      kind: "forward",
+    });
+    assert.deepEqual(decideOnedriveCallbackAction({ code: "abc" }, undefined), {
+      kind: "forward",
+    });
+  });
+
+  it("reports denial when the user rejected the consent screen", () => {
+    assert.deepEqual(
+      decideOnedriveCallbackAction(
+        { error: "access_denied", error_description: "The user has denied" },
+        "some-verifier"
+      ),
+      { kind: "denied", errorDescription: "The user has denied" }
+    );
+  });
+
+  it("marks anything else as invalid", () => {
+    assert.deepEqual(decideOnedriveCallbackAction({}, "v"), {
+      kind: "invalid",
+    });
+  });
+});
+
+describe("decideCredentialAction", () => {
+  it("keeps credentials when there is no refresh token", () => {
+    assert.equal(
+      decideCredentialAction({
+        hasRefreshToken: false,
+        deleteAtTimeMs: 0,
+        nowMs: 100,
+      }),
+      "keep"
+    );
+  });
+
+  it("keeps credentials before the deadline", () => {
+    assert.equal(
+      decideCredentialAction({
+        hasRefreshToken: true,
+        deleteAtTimeMs: 200,
+        nowMs: 100,
+      }),
+      "keep"
+    );
+  });
+
+  it("asks for a refresh attempt after the deadline - never a wipe", () => {
+    assert.equal(
+      decideCredentialAction({
+        hasRefreshToken: true,
+        deleteAtTimeMs: 100,
+        nowMs: 200,
+      }),
+      "refresh-or-prompt"
+    );
+  });
+});


### PR DESCRIPTION
Four OneDrive (App Folder) fixes, each diagnosed and verified against a live OneDrive personal account on Obsidian 1.13.7 desktop in August 2026. Addresses #1185 and the recurring auth-hang reports (#920, #1142).

## 1. Auth hangs forever with more than one vault window open

Obsidian delivers `obsidian://` callbacks to a single window, its most recently active one. With several vault windows open, the one-time auth code lands in a vault that never started an auth. That vault passed the old guard (`verifier !== undefined` is true for an empty string), consumed the code with an empty PKCE verifier, and burned it: Microsoft returns 400, the error notices appear only in the wrong window, and the vault that started the auth hangs on "Connecting to OneDrive" forever. Reproduced three times in controlled runs; the token endpoint 400 with `invalid_grant` was observed in the receiving window each time.

Fix: a window with no pending auth never consumes the code. It forwards the callback params over a `BroadcastChannel` (verified to cross vault windows, guarded with a `typeof` check for older platforms) so the window that is waiting completes the exchange, and it shows a notice explaining what happened.

## 2. Silent failures in the callback handler

Any error after the code arrived left the modal hanging with no message. Two concrete cases hit during testing: the token exchange failing, and the username fetch crashing because it used `getClient()` with the currently selected service type (`Region is missing` from the S3 client after a successful OneDrive auth). The handler now wraps the flow, surfaces errors in the modal and a notice, and always uses a OneDrive client for the username fetch.

## 3. Token lifecycle

- `setConfigBySuccessfullAuthInplace` added `expires_in` (seconds) as milliseconds, so every fresh access token was already "expired" and each sync burned an extra refresh round-trip. Possibly relevant to the 429 reports (#912, #1121).
- `credentialsShouldBeDeletedAtTime` was only extended on a full manual re-auth, so users were forced to re-auth every ~80 days even when syncing (and refreshing) daily, and the expiry handler deleted the entire OneDrive config, settings included, without trying the refresh token first. Now: every successful refresh extends the deadline; at the deadline a refresh is attempted and only the auth fields are cleared if Microsoft rejects it.

## 4. First-connect folder creation returns 400 (#1185)

The reporter of #1185 blamed `@microsoft.graph.conflictBehavior: replace`. Testing shows it is broader: `POST /drive/special/approot/children` returns 400 `invalidRequest` for folder creation with `replace`, `fail`, or no conflictBehavior at all, on `/drive` and `/me/drive` alike. Creating through `POST /me/drive/items/{approot-id}/children` works (201). The code now resolves the approot id and creates through it, with `fail` plus a re-check for races. Verified by deleting the remote vault folder and running a full sync: folder recreated, files uploaded.

## Notes

- Decision logic (expiry computation, callback routing, credential policy) is extracted to `src/oauthLogic.ts` with mocha tests, kept free of `obsidian` imports so the suite can run it.
- `src/` only. New translation key added to en, zh_cn, zh_tw.
- The full investigation lives on my fork's default branch: https://github.com/shantanukhanwalkar/remotely-save